### PR TITLE
Fix DoctrineQueryObjectDataSource count behavior

### DIFF
--- a/src/DataSource/DoctrineQueryObjectDataSource.php
+++ b/src/DataSource/DoctrineQueryObjectDataSource.php
@@ -72,7 +72,7 @@ class DoctrineQueryObjectDataSource implements IDataSource
 	 */
 	public function getCount()
 	{
-		return $this->getResultSet()->getTotalCount();
+		return $this->getResultSet()->count();
 	}
 
 


### PR DESCRIPTION
This is the only difference between `count` and `getTotalCount`. And I think that this control should take care of current `count` of selected items instead of total count of whole set. With this modification you can use this nogrid with filtered QO and paginator. Does it make sense?
